### PR TITLE
Fix icon in dashboard menu

### DIFF
--- a/src/Providers/WhatsAppFloatingButtonServiceProvider.php
+++ b/src/Providers/WhatsAppFloatingButtonServiceProvider.php
@@ -28,7 +28,7 @@ class WhatsAppFloatingButtonServiceProvider extends ServiceProvider
                         'id' => 'plugins-whatsapp-floating-button',
                         'priority' => 9999,
                         'name' => 'plugins/whatsapp-floating-button::whatsapp-floating-button.name',
-                        'icon' => version_compare('7.0.0', get_core_version(), '>=') ? 'ti ti-brand-whatsapp' : 'fab fa-whatsapp',
+                        'icon' => version_compare('7.0.0', get_core_version(), '<=') ? 'ti ti-brand-whatsapp' : 'fab fa-whatsapp',
                         'url' => route('whatsapp-floating-button.settings'),
                     ]);
 


### PR DESCRIPTION
It is still using FontAwesome. Need to change the condition.
<img width="753" alt="image" src="https://github.com/datlechin/botble-whatsapp-floating-button/assets/6972407/dac5709d-bf16-4c5b-ad01-859040ed0cf5">
