### PR TITLE
Fix JS syntax error when settings contain newlines or quotes

### DIFF
--- a/resources/views/show.blade.php
+++ b/resources/views/show.blade.php
@@ -14,11 +14,11 @@
 
         if (whatsappFloatingButton) {
             $(whatsappFloatingButton).floatingWhatsApp({
-                phone: {!! json_encode(setting('whatsapp-floating-button.phone_number', '')) !!},
-                popupMessage: {!! json_encode(Str::limit(setting('whatsapp-floating-button.popup_message', ''), 220)) !!},
-                showPopup: {!! json_encode(setting('whatsapp-floating-button.show_popup', false)) !!},
-                headerTitle: {!! json_encode(setting('whatsapp-floating-button.popup_title', '')) !!},
-                position: {!! json_encode(setting('whatsapp-floating-button.position', 'right')) !!},
+                phone: @json(setting('whatsapp-floating-button.phone_number', '')),
+                popupMessage: @json(Str::limit(setting('whatsapp-floating-button.popup_message', ''), 220)),
+                showPopup: @json(setting('whatsapp-floating-button.show_popup', false)),
+                headerTitle: @json(setting('whatsapp-floating-button.popup_title', '')),
+                position: @json(setting('whatsapp-floating-button.position', 'right')),
                 size: "{{ setting('whatsapp-floating-button.size', 60) }}px",
                 backgroundColor: '#25D366',
                 showOnIE: !0,

--- a/resources/views/show.blade.php
+++ b/resources/views/show.blade.php
@@ -14,17 +14,17 @@
 
         if (whatsappFloatingButton) {
             $(whatsappFloatingButton).floatingWhatsApp({
-                phone: "{{ setting('whatsapp-floating-button.phone_number') }}",
-                popupMessage: "{{ Str::limit(setting('whatsapp-floating-button.popup_message'), 220)}}",
-                showPopup: "{{ setting('whatsapp-floating-button.show_popup', false) }}",
-                headerTitle: "{{ setting('whatsapp-floating-button.popup_title') }}",
-                position: "{{ setting('whatsapp-floating-button.position', 'right') }}",
+                phone: {!! json_encode(setting('whatsapp-floating-button.phone_number', '')) !!},
+                popupMessage: {!! json_encode(Str::limit(setting('whatsapp-floating-button.popup_message', ''), 220)) !!},
+                showPopup: {!! json_encode(setting('whatsapp-floating-button.show_popup', false)) !!},
+                headerTitle: {!! json_encode(setting('whatsapp-floating-button.popup_title', '')) !!},
+                position: {!! json_encode(setting('whatsapp-floating-button.position', 'right')) !!},
                 size: "{{ setting('whatsapp-floating-button.size', 60) }}px",
                 backgroundColor: '#25D366',
                 showOnIE: !0,
                 autoOpenTimeout: 0,
                 headerColor: '#128C7E',
-                zIndex: {{ setting('whatsapp-floating-button.z_index', 999) }},
+                zIndex: {{ (int) setting('whatsapp-floating-button.z_index', 999) }},
             });
         }
     });


### PR DESCRIPTION
## Summary
- Use `json_encode()` instead of Blade `{{ }}` for rendering setting values into JavaScript string literals
- The `popup_message` field is a textarea that can contain newlines and quotes, which break the JS when rendered with `{{ }}` (HTML-escaping only)
- `json_encode()` properly escapes all special characters (`\n`, `"`, etc.) for JavaScript context
- Cast `z_index` to `int` to prevent injection

## Problem
When users enter multi-line text or text with quotes in the popup message textarea, the rendered JavaScript breaks because `{{ }}` only HTML-escapes — it doesn't escape newlines or JS-special characters.

**Screenshot of the bug (rendered HTML source):**

> Please see the attached screenshot in the PR comment below showing the broken JS output where `popupMessage` spans multiple lines with unescaped quotes.

## Test plan
- [ ] Enter a multi-line popup message with quotes and verify no JS errors
- [ ] Verify the WhatsApp button renders correctly with special characters in all fields